### PR TITLE
bugfix: bcrypt-node-gyp

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -4,14 +4,10 @@ WORKDIR /app/builder
 
 COPY . .
 
+RUN npm rebuild bcrypt --build-from-source
+
 RUN npx nx build server
 
 RUN npm prune --production
-
-FROM node:16-alpine
-
-WORKDIR /app
-
-COPY --from=builder /app/builder ./
 
 CMD ["node", "./dist/apps/server/main.js"]

--- a/apps/server/src/config/root.config.ts
+++ b/apps/server/src/config/root.config.ts
@@ -20,7 +20,9 @@ export const youtube: Youtube = {
 
 export const mongoDB: MongoDB = {
   database_test: 'mongodb://localhost/db_yemusic_test',
-  database: process.env.YEMUSIC_DB_CONNECTION_STRING || 'mongodb://localhost/db_yemusic_test',
+  database_host: process.env.DB_HOST || 'localhost',
+  database: process.env.DB_DEFAULT || 'db_yemusic',
+  database_url: process.env.YEMUSIC_DB_CONNECTION_STRING,
   mongoOptions: {},
 };
 

--- a/apps/server/src/config/type.config.ts
+++ b/apps/server/src/config/type.config.ts
@@ -21,6 +21,8 @@ export type Youtube = {
 
 export type MongoDB = {
   database_test: string;
+  database_url: string;
+  database_host: string;
   database: string;
   mongoOptions: object;
 };

--- a/apps/server/src/provider/mongoose.ts
+++ b/apps/server/src/provider/mongoose.ts
@@ -3,11 +3,15 @@ import * as mongoose from 'mongoose';
 import { mongoDB } from '../config';
 
 export const loadMongo = async () => {
-  mongoose.connect(mongoDB.database, mongoDB.mongoOptions, err => {
-    if (err) {
-      logger.info(`💩 mongodb connection failed ${err}`);
-    } else {
-      logger.info('🌈 hello from mongodb');
+  mongoose.connect(
+    mongoDB.database_url || `mongodb://${mongoDB.database_host}/${mongoDB.database}`,
+    mongoDB.mongoOptions,
+    err => {
+      if (err) {
+        logger.info(`💩 mongodb connection failed ${err}`);
+      } else {
+        logger.info('🌈 hello from mongodb');
+      }
     }
-  });
+  );
 };

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -34,6 +34,8 @@ services:
     image: $DOCKERHUB_USERNAME/vc-yemusic:server-api
     environment:
       - API_PORT=$YEMUSIC_API_SERVER_PORT
+      - DB_HOST=mongodb
+      - DB_DEFAULT=db_yemusic
     ports:
       - 4902:$YEMUSIC_API_SERVER_PORT
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,8 @@ services:
       dockerfile: ./apps/server/Dockerfile
     environment:
       - API_PORT=$YEMUSIC_API_SERVER_PORT
+      - DB_HOST=mongodb
+      - DB_DEFAULT=db_yemusic
     ports:
       - 4902:$YEMUSIC_API_SERVER_PORT
     networks:

--- a/nx.json
+++ b/nx.json
@@ -17,7 +17,8 @@
     "default": {
       "runner": "@nrwl/workspace/tasks-runners/default",
       "options": {
-        "cacheableOperations": ["build", "lint", "test", "e2e", "build-storybook"]
+        "cacheableOperations": ["build", "lint", "test", "e2e", "build-storybook"],
+        "useDaemonProcess": false
       }
     }
   },


### PR DESCRIPTION
- Rebuild `bcrypt` when building docker image.
- Add env for mongo connection in staging.
- Set NX Daemon to default